### PR TITLE
Fix package not being found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [project.urls]
 Homepage = "https://github.com/disguise-one/python-plugin"
 Issues = "https://github.com/disguise-one/python-plugin/issues"


### PR DESCRIPTION
# Fix package not being found

## Summary

The `pyproject.toml` is missing package discovery configuration.

As `src/designer_plugin/` package needs to be dicovered, I have added:
```toml
[tool.setuptools.packages.find]
where = ["src"]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated packaging configuration to correctly discover packages located under the src directory during installation and distribution. This improves packaging reliability and consistency across environments. No functional changes, new features, or dependency updates; existing behavior remains unchanged. End users should not notice any differences. Applies to future builds and releases only. No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->