### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check version not already published
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if uv pip index versions designer-plugin 2>/dev/null | grep -q "$VERSION"; then
+            echo "Version $VERSION already exists on PyPI. Aborting."
+            exit 1
+          fi
+
+      - name: Build package
+        run: uv build
+
+      - name: Tag release
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.version.outputs.version }}" || echo "Tag already exists, skipping"
+          git push origin "v${{ steps.version.outputs.version }}" || echo "Tag already pushed, skipping"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,11 @@ permissions:
   id-token: write
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
   publish:
+    needs: ci
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     environment: pypi
@@ -36,15 +40,22 @@ jobs:
             exit 1
           fi
 
+      - name: Validate tag does not exist
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "Tag v${{ steps.version.outputs.version }} already exists. Aborting."
+            exit 1
+          fi
+
       - name: Build package
         run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Tag release
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "v${{ steps.version.outputs.version }}" || echo "Tag already exists, skipping"
-          git push origin "v${{ steps.version.outputs.version }}" || echo "Tag already pushed, skipping"
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ name = "designer-plugin"
 version = "1.3.0"
 description = "Python library for creating Disguise Designer plugins with DNS-SD discovery and remote Python execution"
 authors = [
-    { name = "Tom Whittock", email = "tom.whittock@disguise.one" },
-    { name = "Taegyun Ha", email = "taegyun.ha@disguise.one" }
+    { name = "Taegyun Ha", email = "taegyun.ha@disguise.one" },
+    { name = "Tom Whittock", email = "tom.whittock@disguise.one" }
 ]
 dependencies = [
     "aiohttp>=3.13.2",


### PR DESCRIPTION
# Add release action

## Summary

Adds a manual GitHub Actions workflow to publish the designer-plugin package to PyPI.

- Triggered manually via workflow_dispatch
- Extracts version from pyproject.toml at runtime
- Guards against publishing an already-released version (checks PyPI before building)
- Creates a git tag after publishing, with graceful handling if the tag already exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modules now register automatically on first `execute()` or `rpc()` call (lazy registration).
  * Function dependencies are automatically detected and registered.
  * Enhanced function re-registration with replacement handling.

* **API Changes**
  * Renamed execution functions: `d3_api_plugin` → `d3_api_execute`, `d3_api_aplugin` → `d3_api_aexecute`.
  * `context_modules` parameter type changed to set.
  * Removed `add_packages_in_current_file()` helper.

* **Documentation**
  * Updated registration behavior and Jupyter workarounds in README.
  * Version bumped to 1.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->